### PR TITLE
i/5831: Special characters grid tile should render correctly when the scrollbar shows up in the panel

### DIFF
--- a/src/ui/charactergridview.js
+++ b/src/ui/charactergridview.js
@@ -37,7 +37,18 @@ export default class CharacterGridView extends View {
 
 		this.setTemplate( {
 			tag: 'div',
-			children: this.tiles,
+			children: [
+				{
+					tag: 'div',
+					attributes: {
+						class: [
+							'ck',
+							'ck-character-grid__tiles'
+						]
+					},
+					children: this.tiles
+				}
+			],
 			attributes: {
 				class: [
 					'ck',

--- a/tests/ui/charactergridview.js
+++ b/tests/ui/charactergridview.js
@@ -28,8 +28,18 @@ describe( 'CharacterGridView', () => {
 		} );
 
 		it( 'creates #element from template', () => {
+			const tile = view.createTile( 'ε', 'foo bar baz' );
+			const tilesElement = view.element.firstChild;
+
+			view.tiles.add( tile );
+
 			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-character-grid' ) ).to.be.true;
+
+			expect( tilesElement.classList.contains( 'ck' ) ).to.be.true;
+			expect( tilesElement.classList.contains( 'ck-character-grid__tiles' ) ).to.be.true;
+
+			expect( tile.element.parentNode ).to.equal( tilesElement );
 		} );
 	} );
 

--- a/theme/charactergrid.css
+++ b/theme/charactergrid.css
@@ -4,6 +4,8 @@
  */
 
 .ck.ck-character-grid {
-	display: grid;
-	grid-template-columns: repeat(10, 1fr);
+	& .ck-character-grid__tiles {
+		display: grid;
+		grid-template-columns: repeat( 10, 1fr );
+	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Special characters grid tile should render correctly when the scrollbar shows up in the panel (Safari, Firefox). Closes ckeditor/ckeditor5#5831.

---

### Additional information

This PR is built on top of https://github.com/ckeditor/ckeditor5-special-characters/pull/1. So it should either be merged after it or into it. 

* Requires adjustments in the theme https://github.com/ckeditor/ckeditor5-theme-lark/pull/257
