### PR TITLE
Removed SpecialCharacters from dependencies in sub-plugins

### DIFF
--- a/src/specialcharactersarrows.js
+++ b/src/specialcharactersarrows.js
@@ -8,7 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import SpecialCharacters from './specialcharacters';
 
 /**
  * A plugin provides special characters for the "Arrows" category.
@@ -23,13 +22,6 @@ import SpecialCharacters from './specialcharacters';
  * @extends module:core/plugin~Plugin
  */
 export default class SpecialCharactersArrows extends Plugin {
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ SpecialCharacters ];
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/src/specialcharacterscurrency.js
+++ b/src/specialcharacterscurrency.js
@@ -8,7 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import SpecialCharacters from './specialcharacters';
 
 /**
  * A plugin provides special characters for the "Currency" category.
@@ -23,13 +22,6 @@ import SpecialCharacters from './specialcharacters';
  * @extends module:core/plugin~Plugin
  */
 export default class SpecialCharactersCurrency extends Plugin {
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ SpecialCharacters ];
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/src/specialcharactersessentials.js
+++ b/src/specialcharactersessentials.js
@@ -9,7 +9,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-import SpecialCharacters from './specialcharacters';
 import SpecialCharactersCurrency from './specialcharacterscurrency';
 import SpecialCharactersMathematical from './specialcharactersmathematical';
 import SpecialCharactersArrows from './specialcharactersarrows';
@@ -34,7 +33,6 @@ export default class SpecialCharactersEssentials extends Plugin {
 	 */
 	static get requires() {
 		return [
-			SpecialCharacters,
 			SpecialCharactersCurrency,
 			SpecialCharactersText,
 			SpecialCharactersMathematical,

--- a/src/specialcharacterslatin.js
+++ b/src/specialcharacterslatin.js
@@ -8,7 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import SpecialCharacters from './specialcharacters';
 
 /**
  * A plugin provides special characters for the "Latin" category.
@@ -23,13 +22,6 @@ import SpecialCharacters from './specialcharacters';
  * @extends module:core/plugin~Plugin
  */
 export default class SpecialCharactersLatin extends Plugin {
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ SpecialCharacters ];
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/src/specialcharactersmathematical.js
+++ b/src/specialcharactersmathematical.js
@@ -8,7 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import SpecialCharacters from './specialcharacters';
 
 /**
  * A plugin provides special characters for the "Mathematical" category.
@@ -23,13 +22,6 @@ import SpecialCharacters from './specialcharacters';
  * @extends module:core/plugin~Plugin
  */
 export default class SpecialCharactersMathematical extends Plugin {
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ SpecialCharacters ];
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/src/specialcharacterstext.js
+++ b/src/specialcharacterstext.js
@@ -8,7 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import SpecialCharacters from './specialcharacters';
 
 /**
  * A plugin provides special characters for the "Text" category.
@@ -23,13 +22,6 @@ import SpecialCharacters from './specialcharacters';
  * @extends module:core/plugin~Plugin
  */
 export default class SpecialCharactersText extends Plugin {
-	/**
-	 * @inheritDoc
-	 */
-	static get requires() {
-		return [ SpecialCharacters ];
-	}
-
 	/**
 	 * @inheritDoc
 	 */

--- a/tests/specialcharacters.js
+++ b/tests/specialcharacters.js
@@ -40,6 +40,7 @@ describe( 'SpecialCharacters', () => {
 			return ClassicTestEditor
 				.create( element, {
 					plugins: [
+						SpecialCharacters,
 						SpecialCharactersMathematical,
 						SpecialCharactersArrows
 					]

--- a/tests/specialcharactersessentials.js
+++ b/tests/specialcharactersessentials.js
@@ -5,7 +5,6 @@
 
 import SpecialCharactersEssentials from '../src/specialcharactersessentials';
 
-import SpecialCharacters from '../src/specialcharacters';
 import SpecialCharactersCurrency from '../src/specialcharacterscurrency';
 import SpecialCharactersText from '../src/specialcharacterstext';
 import SpecialCharactersMathematical from '../src/specialcharactersmathematical';
@@ -15,7 +14,6 @@ import SpecialCharactersLatin from '../src/specialcharacterslatin';
 describe( 'SpecialCharactersEssentials', () => {
 	it( 'includes other required plugins', () => {
 		expect( SpecialCharactersEssentials.requires ).to.deep.equal( [
-			SpecialCharacters,
 			SpecialCharactersCurrency,
 			SpecialCharactersText,
 			SpecialCharactersMathematical,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed the `SpecialCharacters` plugin from dependencies in sub-plugins (`SpecialCharactersXXX`). Closes ckeditor/ckeditor5#5981.