### PR TITLE
Corrected the docs for special characters

### DIFF
--- a/docs/_snippets/features/special-characters-extended-category.js
+++ b/docs/_snippets/features/special-characters-extended-category.js
@@ -24,8 +24,6 @@ ClassicEditor
 				'outdent',
 				'indent',
 				'|',
-				'alignment',
-				'|',
 				'specialCharacters',
 				'blockQuote',
 				'link',

--- a/docs/_snippets/features/special-characters-extended-category.js
+++ b/docs/_snippets/features/special-characters-extended-category.js
@@ -3,15 +3,22 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window, document, console, ClassicEditor */
+/* globals window, document, console, ClassicEditor, SpecialCharactersEssentials */
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
+function SpecialCharactersArrowsExtended( editor ) {
+	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
+		{ title: 'simple arrow left', character: '←' },
+		{ title: 'simple arrow up', character: '↑' },
+		{ title: 'simple arrow right', character: '→' },
+		{ title: 'simple arrow down', character: '↓' }
+	] );
+}
+
 ClassicEditor
 	.create( document.querySelector( '#snippet-special-characters-extended-category' ), {
-		removePlugins: [
-			'SpecialCharactersEmoji'
-		],
+		extraPlugins: [ SpecialCharactersEssentials, SpecialCharactersArrowsExtended ],
 		toolbar: {
 			items: [
 				'heading',

--- a/docs/_snippets/features/special-characters-limited-categories.html
+++ b/docs/_snippets/features/special-characters-limited-categories.html
@@ -1,0 +1,15 @@
+<div id="snippet-special-characters-limited-categories">
+	<h2 style="text-align:center;">The Flavorful Tuscany Meetup</h2>
+	<h3 style="text-align:center;">Welcome letter</h3>
+	<p>Dear Guest,</p>
+	<p>We are delighted to welcome you to the annual <i>Flavorful Tuscany Meetup</i> and hope you will enjoy the programme as well as your stay at the <a href="https://ckeditor.com">Bilancino Hotel</a>.</p>
+	<p>Please arrive at the <a href="https://ckeditor.com">Bilancino Hotel</a> reception desk at least half an hour earlier to make sure that the registration process goes as smoothly as possible.</p>
+	<p>We look forward to welcoming you to the event. The full schedule can be found below.</p>
+</div>
+
+<style>
+	.ck-content h2 {
+		border-bottom: none;
+		margin-bottom: 0;
+	}
+</style>

--- a/docs/_snippets/features/special-characters-limited-categories.js
+++ b/docs/_snippets/features/special-characters-limited-categories.js
@@ -1,0 +1,61 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals window, document, console, ClassicEditor, SpecialCharactersCurrency, SpecialCharactersMathematical */
+
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+ClassicEditor
+	.create( document.querySelector( '#snippet-special-characters-limited-categories' ), {
+		extraPlugins: [ SpecialCharactersCurrency, SpecialCharactersMathematical ],
+		toolbar: {
+			items: [
+				'heading',
+				'|',
+				'bold',
+				'italic',
+				'bulletedList',
+				'numberedList',
+				'|',
+				'outdent',
+				'indent',
+				'|',
+				'specialCharacters',
+				'blockQuote',
+				'link',
+				'imageUpload',
+				'mediaEmbed',
+				'insertTable',
+				'|',
+				'undo',
+				'redo'
+			],
+			viewportTopOffset: window.getViewportTopOffsetConfig()
+		},
+		image: {
+			styles: [
+				'full',
+				'alignLeft',
+				'alignRight'
+			],
+			toolbar: [
+				'imageStyle:alignLeft',
+				'imageStyle:full',
+				'imageStyle:alignRight',
+				'|',
+				'imageTextAlternative'
+			]
+		},
+		table: {
+			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
+		},
+		cloudServices: CS_CONFIG
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/docs/_snippets/features/special-characters-new-category.js
+++ b/docs/_snippets/features/special-characters-new-category.js
@@ -7,6 +7,16 @@
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
+function ExtraCat( editor ) {
+	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji2', [
+		{ title: 'smiley face', character: '😊' },
+		{ title: 'rocket', character: '🚀' },
+		{ title: 'basketball', character: '🏀' },
+		{ title: 'floppy disk', character: '💾' },
+		{ title: 'hearth', character: '❤' }
+	] );
+}
+
 ClassicEditor
 	.create( document.querySelector( '#snippet-special-characters-new-category' ), {
 		removePlugins: [
@@ -23,8 +33,6 @@ ClassicEditor
 				'|',
 				'outdent',
 				'indent',
-				'|',
-				'alignment',
 				'|',
 				'specialCharacters',
 				'blockQuote',
@@ -52,6 +60,7 @@ ClassicEditor
 				'imageTextAlternative'
 			]
 		},
+		extraPlugins: [ ExtraCat ],
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
 		},

--- a/docs/_snippets/features/special-characters-new-category.js
+++ b/docs/_snippets/features/special-characters-new-category.js
@@ -3,12 +3,12 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window, document, console, ClassicEditor */
+/* globals window, document, console, ClassicEditor, SpecialCharactersEssentials */
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
-function ExtraCat( editor ) {
-	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji2', [
+function SpecialCharactersEmoji( editor ) {
+	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji', [
 		{ title: 'smiley face', character: '😊' },
 		{ title: 'rocket', character: '🚀' },
 		{ title: 'basketball', character: '🏀' },
@@ -19,9 +19,7 @@ function ExtraCat( editor ) {
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-special-characters-new-category' ), {
-		removePlugins: [
-			'SpecialCharactersArrowsExtended'
-		],
+		extraPlugins: [ SpecialCharactersEssentials, SpecialCharactersEmoji ],
 		toolbar: {
 			items: [
 				'heading',
@@ -60,7 +58,6 @@ ClassicEditor
 				'imageTextAlternative'
 			]
 		},
-		extraPlugins: [ ExtraCat ],
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
 		},

--- a/docs/_snippets/features/special-characters-source.js
+++ b/docs/_snippets/features/special-characters-source.js
@@ -7,7 +7,6 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
-import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
 import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
 import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
 
@@ -42,7 +41,6 @@ class SpecialCharactersArrowsExtended extends Plugin {
 	}
 }
 
-ClassicEditor.builtinPlugins.push( Alignment );
 ClassicEditor.builtinPlugins.push( SpecialCharacters );
 ClassicEditor.builtinPlugins.push( SpecialCharactersEssentials );
 ClassicEditor.builtinPlugins.push( SpecialCharactersEmoji );

--- a/docs/_snippets/features/special-characters-source.js
+++ b/docs/_snippets/features/special-characters-source.js
@@ -5,7 +5,6 @@
 
 /* globals window */
 
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
 import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
 import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
@@ -19,4 +18,3 @@ window.SpecialCharacters = SpecialCharacters;
 window.SpecialCharactersCurrency = SpecialCharactersCurrency;
 window.SpecialCharactersMathematical = SpecialCharactersMathematical;
 window.SpecialCharactersEssentials = SpecialCharactersEssentials;
-window.Plugin = Plugin;

--- a/docs/_snippets/features/special-characters-source.js
+++ b/docs/_snippets/features/special-characters-source.js
@@ -9,41 +9,14 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
 import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
 import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
-
-class SpecialCharactersEmoji extends Plugin {
-	static get pluginName() {
-		return 'SpecialCharactersEmoji';
-	}
-
-	init() {
-		this.editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji', [
-			{ title: 'smiley face', character: '😊' },
-			{ title: 'rocket', character: '🚀' },
-			{ title: 'basketball', character: '🏀' },
-			{ title: 'floppy disk', character: '💾' },
-			{ title: 'hearth', character: '❤' }
-		] );
-	}
-}
-
-class SpecialCharactersArrowsExtended extends Plugin {
-	static get pluginName() {
-		return 'SpecialCharactersArrowsExtended';
-	}
-
-	init() {
-		this.editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
-			{ title: 'simple arrow left', character: '←' },
-			{ title: 'simple arrow up', character: '↑' },
-			{ title: 'simple arrow right', character: '→' },
-			{ title: 'simple arrow down', character: '↓' }
-		] );
-	}
-}
+import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/SpecialCharactersCurrency';
+import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/SpecialCharactersMathematical';
 
 ClassicEditor.builtinPlugins.push( SpecialCharacters );
-ClassicEditor.builtinPlugins.push( SpecialCharactersEssentials );
-ClassicEditor.builtinPlugins.push( SpecialCharactersEmoji );
-ClassicEditor.builtinPlugins.push( SpecialCharactersArrowsExtended );
 
 window.ClassicEditor = ClassicEditor;
+window.SpecialCharacters = SpecialCharacters;
+window.SpecialCharactersCurrency = SpecialCharactersCurrency;
+window.SpecialCharactersMathematical = SpecialCharactersMathematical;
+window.SpecialCharactersEssentials = SpecialCharactersEssentials;
+window.Plugin = Plugin;

--- a/docs/_snippets/features/special-characters.js
+++ b/docs/_snippets/features/special-characters.js
@@ -3,16 +3,13 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window, document, console, ClassicEditor */
+/* globals window, document, console, ClassicEditor, SpecialCharactersEssentials */
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-special-characters' ), {
-		removePlugins: [
-			'SpecialCharactersEmoji',
-			'SpecialCharactersArrowsExtended'
-		],
+		extraPlugins: [ SpecialCharactersEssentials ],
 		toolbar: {
 			items: [
 				'heading',

--- a/docs/_snippets/features/special-characters.js
+++ b/docs/_snippets/features/special-characters.js
@@ -25,8 +25,6 @@ ClassicEditor
 				'outdent',
 				'indent',
 				'|',
-				'alignment',
-				'|',
 				'specialCharacters',
 				'blockQuote',
 				'link',

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -90,18 +90,18 @@ Use the special characters icon in the editor's toolbar then select "Arrows" in 
 
 ### Removing special character categories
 
-Special characters feature exposes each category as a separate plugin. While `SpecialCharactersEssentials` plugin can be used to conveniently include all of them, you can customize the category list by adding individual plugins.
+The special characters feature exposes each category as a separate plugin. While the {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} plugin can be used to conveniently include all of them, you can customize the category list by adding individual plugins.
 
 The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
 
 - {@link module:special-characters/specialcharactersarrows~SpecialCharactersArrows} – arrows special characters,
 - {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} - currency special characters,
 - {@link module:special-characters/specialcharacterslatin~SpecialCharactersLatin} – Latin special characters,
-- {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – Mathematical special characters,
+- {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – mathematical special characters,
 - {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
 - {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
 
-For example, you can limit categories to "Mathematical" and "Currency" only by picking following plugins:
+For example, you can limit categories to "Mathematical" and "Currency" only by picking the {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} and {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} plugins, like so:
 
 ```js
 import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
@@ -119,7 +119,7 @@ ClassicEditor
 
 #### Removing special character categories demo
 
-After clicking special character icon in the editor's toolbar you can see that only few categories are available compared to other instances.
+After clicking the special character icon in the editor's toolbar you can see that it contains fewer categories compared to other instances.
 
 {@snippet features/special-characters-limited-categories}
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -15,7 +15,9 @@ Use the editor below to see the {@link module:special-characters/specialcharacte
 
 {@snippet features/special-characters}
 
-## Special characters in the package
+## Configuration
+
+### Special characters in the package
 
 The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
 
@@ -26,7 +28,7 @@ The `@ckeditor/ckeditor5-special-characters` package provides special characters
 - {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
 - {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
 
-## Adding a new special character category
+### Adding a new special character category
 
 You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
 
@@ -58,13 +60,13 @@ After adding the above plugin into the editor, the new special characters catego
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-### Custom special characters category demo
+#### Custom special characters category demo
 
 Use the special character icon in the editor's toolbar then select `Emoji` in the select dropdown in order to insert a emoji into the editor.
 
 {@snippet features/special-characters-new-category}
 
-## Adding a new special characters to existing category
+### Adding a new special characters to existing category
 
 By using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function, you can also add new special characters into existing category.
 
@@ -90,7 +92,7 @@ class SpecialCharactersArrowsExtended extends Plugin {
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-### Extending existing special characters category category demo
+#### Extending existing special characters category category demo
 
 Use the special character icon in the editor's toolbar then select `Arrows` in the select dropdown in order to add new arrows.
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -24,6 +24,9 @@ You can define a new special characters category using the {@link module:special
 For example, the following plugin adds the "Emoji" category in the special characters dropdown.
 
 ```js
+import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
+import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
+
 function SpecialCharactersEmoji( editor ) {
 	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji', [
 		{ title: 'smiley face', character: '😊' },
@@ -60,6 +63,9 @@ Use the special characters icon in the editor's toolbar then select "Emoji" in t
 By using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function, you can also add new special characters into existing category.
 
 ```js
+import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
+import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
+
 function SpecialCharactersArrowsExtended( editor ) {
 	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
 		{ title: 'simple arrow left', character: '←' },
@@ -105,8 +111,8 @@ For example, you can limit categories to "Mathematical" and "Currency" only by p
 
 ```js
 import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
-import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/SpecialCharactersCurrency';
-import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/SpecialCharactersMathematical';
+import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/specialcharacterscurrency';
+import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/specialcharactersmathematical';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -49,13 +49,13 @@ After adding the above plugin into the editor, the new special characters catego
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-#### Custom special characters category demo
+#### Adding special characters category demo
 
 Use the special character icon in the editor's toolbar then select "Emoji" in the select dropdown in order to insert a emoji into the editor.
 
 {@snippet features/special-characters-new-category}
 
-### Adding a new special characters to existing category
+### Adding a new special characters to an existing category
 
 By using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function, you can also add new special characters into existing category.
 
@@ -82,7 +82,7 @@ ClassicEditor
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-#### Extending existing special characters category demo
+#### Extending an existing special characters category demo
 
 Use the special character icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
 
@@ -90,7 +90,7 @@ Use the special character icon in the editor's toolbar then select "Arrows" in t
 
 ### Removing special character categories
 
-Special characters feature exposes each category as a separate plugin. While `SpecialCharactersEssentials` plugin could be used to conveniently include all of them, you can customize the category list by adding individual of plugins.
+Special characters feature exposes each category as a separate plugin. While `SpecialCharactersEssentials` plugin can be used to conveniently include all of them, you can customize the category list by adding individual plugins.
 
 The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -43,7 +43,7 @@ ClassicEditor
 	.catch( ... );
 ```
 
-After adding the above plugin into the editor, the new special characters category will be available in the dropdown.
+After adding the above plugin into the editor, the new category will be available in the special characters dropdown.
 
 <info-box>
 	A title of a special character must be unique across the entire special characters set.
@@ -51,7 +51,7 @@ After adding the above plugin into the editor, the new special characters catego
 
 #### Adding special characters category demo
 
-Use the special character icon in the editor's toolbar then select "Emoji" in the select dropdown in order to insert a emoji into the editor.
+Use the special characters icon in the editor's toolbar then select "Emoji" in the select dropdown in order to insert a emoji into the editor.
 
 {@snippet features/special-characters-new-category}
 
@@ -84,7 +84,7 @@ ClassicEditor
 
 #### Extending an existing special characters category demo
 
-Use the special character icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
+Use the special characters icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
 
 {@snippet features/special-characters-extended-category}
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -45,7 +45,7 @@ class SpecialCharactersEmoji extends Plugin {
 
 After adding the above plugin into the editor, the new special characters category will be available in the dropdown.
 
-<info-box warning>
+<info-box>
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
@@ -77,7 +77,7 @@ class SpecialCharactersArrowsExtended extends Plugin {
 }
 ```
 
-<info-box warning>
+<info-box>
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -21,7 +21,7 @@ Use the editor below to see the {@link module:special-characters/specialcharacte
 
 You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
 
-For example, the following plugin adds the `Emoji` category in the special characters dropdown.
+For example, the following plugin adds the "Emoji" category in the special characters dropdown.
 
 ```js
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
@@ -51,7 +51,7 @@ After adding the above plugin into the editor, the new special characters catego
 
 #### Custom special characters category demo
 
-Use the special character icon in the editor's toolbar then select `Emoji` in the select dropdown in order to insert a emoji into the editor.
+Use the special character icon in the editor's toolbar then select "Emoji" in the select dropdown in order to insert a emoji into the editor.
 
 {@snippet features/special-characters-new-category}
 
@@ -66,7 +66,6 @@ class SpecialCharactersArrowsExtended extends Plugin {
 	}
 
 	init() {
-		// The `Arrows` category is provided by the `SpecialCharactersArrows` plugin.
 		this.editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
 			{ title: 'simple arrow left', character: '←' },
 			{ title: 'simple arrow up', character: '↑' },
@@ -83,7 +82,7 @@ class SpecialCharactersArrowsExtended extends Plugin {
 
 #### Extending existing special characters category category demo
 
-Use the special character icon in the editor's toolbar then select `Arrows` in the select dropdown in order to add new arrows.
+Use the special character icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
 
 {@snippet features/special-characters-extended-category}
 
@@ -115,6 +114,12 @@ ClassicEditor
 	.then( ... )
 	.catch( ... );
 ```
+
+#### Removing special character categories demo
+
+After clicking special character icon in the editor's toolbar you can see that only few categories are available compared to other instances.
+
+{@snippet features/special-characters-limited-categories}
 
 ## Installation
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -31,7 +31,7 @@ The `@ckeditor/ckeditor5-special-characters` package provides special characters
 You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
 
 <info-box warning>
-    The "All" category name is reserved by the plugin and cannot be used as a new name for special characters category.
+	The "All" category name is reserved by the plugin and cannot be used as a new name for special characters category.
 </info-box>
 
 For example, the following plugin adds the `Emoji` category in the special characters dropdown.
@@ -59,7 +59,7 @@ export default class SpecialCharactersEmoji extends Plugin {
 After adding the above plugin into the editor, the new special characters category will be available in the dropdown.
 
 <info-box warning>
-    A title of a special character must be unique across the entire special characters set.
+	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
 ### Custom special characters category demo
@@ -79,7 +79,7 @@ class SpecialCharactersArrowsExtended extends Plugin {
 	}
 
 	init() {
-        // The `Arrows` category is provided by the `SpecialCharactersArrows` plugin.
+		// The `Arrows` category is provided by the `SpecialCharactersArrows` plugin.
 		this.editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
 			{ title: 'simple arrow left', character: '←' },
 			{ title: 'simple arrow up', character: '↑' },
@@ -91,7 +91,7 @@ class SpecialCharactersArrowsExtended extends Plugin {
 ```
 
 <info-box warning>
-    A title of a special character must be unique across the entire special characters set.
+	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
 ### Extending existing special characters category category demo

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -17,7 +17,7 @@ Use the editor below to see the {@link module:special-characters/specialcharacte
 
 ## Configuration
 
-### Adding a new special character category
+### Adding a new category
 
 You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
 
@@ -39,7 +39,11 @@ function SpecialCharactersEmoji( editor ) {
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ SpecialCharacters, SpecialCharactersEssentials, SpecialCharactersEmoji, ... ],
+		plugins: [
+			SpecialCharacters, SpecialCharactersEssentials, SpecialCharactersEmoji,
+
+			// Other plugins...
+		],
 		toolbar: [ 'specialCharacters', ... ],
 	} )
 	.then( ... )
@@ -52,13 +56,11 @@ After adding the above plugin into the editor, the new category will be availabl
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-#### Adding special characters category demo
-
-Use the special characters icon in the editor's toolbar then select "Emoji" in the select dropdown in order to insert a emoji into the editor.
+Below, you can see a demo based on the example shown above. Use the special characters icon in the editor's toolbar then select "Emoji" in the select dropdown in order to insert a emoji into the editor.
 
 {@snippet features/special-characters-new-category}
 
-### Adding a new special characters to an existing category
+### Adding characters to an existing category
 
 By using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function, you can also add new special characters into existing category.
 
@@ -77,7 +79,11 @@ function SpecialCharactersArrowsExtended( editor ) {
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ SpecialCharacters, SpecialCharactersEssentials, SpecialCharactersArrowsExtended, ... ],
+		plugins: [
+			SpecialCharacters, SpecialCharactersEssentials, SpecialCharactersArrowsExtended,
+
+			// Other plugins...
+		],
 		toolbar: [ 'specialCharacters', ... ],
 	} )
 	.then( ... )
@@ -88,24 +94,22 @@ ClassicEditor
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-#### Extending an existing special characters category demo
-
-Use the special characters icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
+Below, you can see a demo based on the example shown above. Use the special characters icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
 
 {@snippet features/special-characters-extended-category}
 
-### Removing special character categories
+### Removing categories
 
 The special characters feature exposes each category as a separate plugin. While the {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} plugin can be used to conveniently include all of them, you can customize the category list by adding individual plugins.
 
 The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
 
-- {@link module:special-characters/specialcharactersarrows~SpecialCharactersArrows} – arrows special characters,
-- {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} - currency special characters,
-- {@link module:special-characters/specialcharacterslatin~SpecialCharactersLatin} – Latin special characters,
-- {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – mathematical special characters,
-- {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
-- {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
+* {@link module:special-characters/specialcharactersarrows~SpecialCharactersArrows} – arrows special characters,
+* {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} - currency special characters,
+* {@link module:special-characters/specialcharacterslatin~SpecialCharactersLatin} – Latin special characters,
+* {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – mathematical special characters,
+* {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
+* {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
 
 For example, you can limit categories to "Mathematical" and "Currency" only by picking the {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} and {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} plugins, like so:
 
@@ -116,16 +120,18 @@ import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-character
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ SpecialCharacters, SpecialCharactersCurrency, SpecialCharactersMathematical, ... ],
+		plugins: [
+			SpecialCharacters, SpecialCharactersCurrency, SpecialCharactersMathematical,
+
+			// Other plugins...
+		],
 		toolbar: [ 'specialCharacters', ... ],
 	} )
 	.then( ... )
 	.catch( ... );
 ```
 
-#### Removing special character categories demo
-
-After clicking the special character icon in the editor's toolbar you can see that it contains fewer categories compared to other instances.
+Below, you can see a demo based on the example shown above. After clicking the special character icon in the editor's toolbar you can see that it contains fewer categories compared to other editors on this page.
 
 {@snippet features/special-characters-limited-categories}
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -15,52 +15,6 @@ Use the editor below to see the {@link module:special-characters/specialcharacte
 
 {@snippet features/special-characters}
 
-## Installation
-
-To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-special-characters`](https://www.npmjs.com/package/@ckeditor/ckeditor5-special-characters) package:
-
-```plaintext
-npm install --save @ckeditor/ckeditor5-special-characters
-```
-
-And add it to your plugin list configuration:
-
-```js
-// The plugin provides API for management special characters and their categories. 
-import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
-
-// `SpecialCharacters` does not provide any special character. They are delivered by another plugins.
-// You can import those ones that you want to use in the editor.
-import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/specialcharacterscurrency';
-import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/specialcharactersmathematical';
-import SpecialCharactersArrows from '@ckeditor/ckeditor5-special-characters/src/specialcharactersarrows';
-import SpecialCharactersLatin from '@ckeditor/ckeditor5-special-characters/src/specialcharacterslatin';
-import SpecialCharactersText from '@ckeditor/ckeditor5-special-characters/src/specialcharacterstext';
-
-// Or import the plugin combining basic set of characters. The imports above can be replaced with the `SpecialCharactersEssentials` plugin.
-import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
-
-ClassicEditor
-	.create( document.querySelector( '#editor' ), {
-		plugins: [ SpecialCharacters, ... ],
-		toolbar: [ 'specialCharacters', ... ],
-	} )
-	.then( ... )
-	.catch( ... );
-```
-
-<info-box info>
-	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
-</info-box>
-
-## Common API
-
-The {@link module:special-characters/specialcharacters~SpecialCharacters} plugin registers the UI button component (`'specialCharacters'`).
-
-<info-box>
-	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
-</info-box>
-
 ## Special characters in the package
 
 The `@ckeditor/ckeditor5-special-characters` package provides a few basic special characters grouped into the following categories:
@@ -145,6 +99,52 @@ class SpecialCharactersArrowsExtended extends Plugin {
 Use the special character icon in the editor's toolbar then select `Arrows` in the select dropdown in order to add new arrows.
 
 {@snippet features/special-characters-extended-category}
+
+## Installation
+
+To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-special-characters`](https://www.npmjs.com/package/@ckeditor/ckeditor5-special-characters) package:
+
+```plaintext
+npm install --save @ckeditor/ckeditor5-special-characters
+```
+
+And add it to your plugin list configuration:
+
+```js
+// The plugin provides API for management special characters and their categories.
+import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
+
+// `SpecialCharacters` does not provide any special character. They are delivered by another plugins.
+// You can import those ones that you want to use in the editor.
+import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/specialcharacterscurrency';
+import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/specialcharactersmathematical';
+import SpecialCharactersArrows from '@ckeditor/ckeditor5-special-characters/src/specialcharactersarrows';
+import SpecialCharactersLatin from '@ckeditor/ckeditor5-special-characters/src/specialcharacterslatin';
+import SpecialCharactersText from '@ckeditor/ckeditor5-special-characters/src/specialcharacterstext';
+
+// Or import the plugin combining basic set of characters. The imports above can be replaced with the `SpecialCharactersEssentials` plugin.
+import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ SpecialCharacters, ... ],
+		toolbar: [ 'specialCharacters', ... ],
+	} )
+	.then( ... )
+	.catch( ... );
+```
+
+<info-box info>
+	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
+</info-box>
+
+## Common API
+
+The {@link module:special-characters/specialcharacters~SpecialCharacters} plugin registers the UI button component (`'specialCharacters'`).
+
+<info-box>
+	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
+</info-box>
 
 ## Contribute
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -24,23 +24,23 @@ You can define a new special characters category using the {@link module:special
 For example, the following plugin adds the "Emoji" category in the special characters dropdown.
 
 ```js
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-
-class SpecialCharactersEmoji extends Plugin {
-	static get pluginName() {
-		return 'SpecialCharactersEmoji';
-	}
-
-	init() {
-		this.editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji', [
-			{ title: 'smiley face', character: '😊' },
-			{ title: 'rocket', character: '🚀' },
-			{ title: 'basketball', character: '🏀' },
-			{ title: 'floppy disk', character: '💾' },
-			{ title: 'hearth', character: '❤' }
-		] );
-	}
+function SpecialCharactersEmoji( editor ) {
+	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Emoji', [
+		{ title: 'smiley face', character: '😊' },
+		{ title: 'rocket', character: '🚀' },
+		{ title: 'basketball', character: '🏀' },
+		{ title: 'floppy disk', character: '💾' },
+		{ title: 'hearth', character: '❤' }
+	] );
 }
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ SpecialCharacters, SpecialCharactersEssentials, SpecialCharactersEmoji, ... ],
+		toolbar: [ 'specialCharacters', ... ],
+	} )
+	.then( ... )
+	.catch( ... );
 ```
 
 After adding the above plugin into the editor, the new special characters category will be available in the dropdown.
@@ -60,20 +60,22 @@ Use the special character icon in the editor's toolbar then select "Emoji" in th
 By using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function, you can also add new special characters into existing category.
 
 ```js
-class SpecialCharactersArrowsExtended extends Plugin {
-	static get pluginName() {
-		return 'SpecialCharactersArrowsExtended';
-	}
-
-	init() {
-		this.editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
-			{ title: 'simple arrow left', character: '←' },
-			{ title: 'simple arrow up', character: '↑' },
-			{ title: 'simple arrow right', character: '→' },
-			{ title: 'simple arrow down', character: '↓' }
-		] );
-	}
+function SpecialCharactersArrowsExtended( editor ) {
+	editor.plugins.get( 'SpecialCharacters' ).addItems( 'Arrows', [
+		{ title: 'simple arrow left', character: '←' },
+		{ title: 'simple arrow up', character: '↑' },
+		{ title: 'simple arrow right', character: '→' },
+		{ title: 'simple arrow down', character: '↓' }
+	] );
 }
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ SpecialCharacters, SpecialCharactersEssentials, SpecialCharactersArrowsExtended, ... ],
+		toolbar: [ 'specialCharacters', ... ],
+	} )
+	.then( ... )
+	.catch( ... );
 ```
 
 <info-box>

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -80,7 +80,7 @@ class SpecialCharactersArrowsExtended extends Plugin {
 	A title of a special character must be unique across the entire special characters set.
 </info-box>
 
-#### Extending existing special characters category category demo
+#### Extending existing special characters category demo
 
 Use the special character icon in the editor's toolbar then select "Arrows" in the select dropdown. You'll see that it contains more arrows than the other instances.
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -28,13 +28,13 @@ The `@ckeditor/ckeditor5-special-characters` package provides special characters
 
 ## Adding a new special character category
 
-By using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function, you can define a new special characters category.
+You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
 
 <info-box warning>
     The "All" category name is reserved by the plugin and cannot be used as a new name for special characters category.
 </info-box>
 
-Let's create a simple plugin that provides the `Emoji` category in the special characters dropdown.
+For example, the following plugin adds the `Emoji` category in the special characters dropdown.
 
 ```js
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
@@ -111,23 +111,14 @@ npm install --save @ckeditor/ckeditor5-special-characters
 And add it to your plugin list configuration:
 
 ```js
-// The plugin provides API for management special characters and their categories.
+// Core plugin that provides the API for management special characters and their categories.
 import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
-
-// `SpecialCharacters` does not provide any special character. They are delivered by another plugins.
-// You can import those ones that you want to use in the editor.
-import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/specialcharacterscurrency';
-import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/specialcharactersmathematical';
-import SpecialCharactersArrows from '@ckeditor/ckeditor5-special-characters/src/specialcharactersarrows';
-import SpecialCharactersLatin from '@ckeditor/ckeditor5-special-characters/src/specialcharacterslatin';
-import SpecialCharactersText from '@ckeditor/ckeditor5-special-characters/src/specialcharacterstext';
-
-// Or import the plugin combining basic set of characters. The imports above can be replaced with the `SpecialCharactersEssentials` plugin.
+// Plugin that combines the basic set of special characters.
 import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ SpecialCharacters, ... ],
+		plugins: [ SpecialCharacters, SpecialCharactersEssentials, ... ],
 		toolbar: [ 'specialCharacters', ... ],
 	} )
 	.then( ... )

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -30,16 +30,12 @@ The `@ckeditor/ckeditor5-special-characters` package provides special characters
 
 You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
 
-<info-box warning>
-	The "All" category name is reserved by the plugin and cannot be used as a new name for special characters category.
-</info-box>
-
 For example, the following plugin adds the `Emoji` category in the special characters dropdown.
 
 ```js
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-export default class SpecialCharactersEmoji extends Plugin {
+class SpecialCharactersEmoji extends Plugin {
 	static get pluginName() {
 		return 'SpecialCharactersEmoji';
 	}

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -17,17 +17,6 @@ Use the editor below to see the {@link module:special-characters/specialcharacte
 
 ## Configuration
 
-### Special characters in the package
-
-The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
-
-- {@link module:special-characters/specialcharactersarrows~SpecialCharactersArrows} – arrows special characters,
-- {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} - currency special characters,
-- {@link module:special-characters/specialcharacterslatin~SpecialCharactersLatin} – Latin special characters,
-- {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – Mathematical special characters,
-- {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
-- {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
-
 ### Adding a new special character category
 
 You can define a new special characters category using the {@link module:special-characters/specialcharacters~SpecialCharacters#addItems `SpecialCharacters#addItems()`} function.
@@ -97,6 +86,19 @@ class SpecialCharactersArrowsExtended extends Plugin {
 Use the special character icon in the editor's toolbar then select `Arrows` in the select dropdown in order to add new arrows.
 
 {@snippet features/special-characters-extended-category}
+
+### Removing special character categories
+
+We recommend using `SpecialCharactersEssentials`
+
+The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
+
+- {@link module:special-characters/specialcharactersarrows~SpecialCharactersArrows} – arrows special characters,
+- {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} - currency special characters,
+- {@link module:special-characters/specialcharacterslatin~SpecialCharactersLatin} – Latin special characters,
+- {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – Mathematical special characters,
+- {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
+- {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
 
 ## Installation
 

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -17,13 +17,13 @@ Use the editor below to see the {@link module:special-characters/specialcharacte
 
 ## Special characters in the package
 
-The `@ckeditor/ckeditor5-special-characters` package provides a few basic special characters grouped into the following categories:
+The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
 
 - {@link module:special-characters/specialcharactersarrows~SpecialCharactersArrows} – arrows special characters,
 - {@link module:special-characters/specialcharacterscurrency~SpecialCharactersCurrency} - currency special characters,
 - {@link module:special-characters/specialcharacterslatin~SpecialCharactersLatin} – Latin special characters,
 - {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – Mathematical special characters,
-- {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – Text special characters
+- {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
 - {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
 
 ## Adding a new special character category

--- a/docs/features/special-characters.md
+++ b/docs/features/special-characters.md
@@ -89,7 +89,7 @@ Use the special character icon in the editor's toolbar then select `Arrows` in t
 
 ### Removing special character categories
 
-We recommend using `SpecialCharactersEssentials`
+Special characters feature exposes each category as a separate plugin. While `SpecialCharactersEssentials` plugin could be used to conveniently include all of them, you can customize the category list by adding individual of plugins.
 
 The `@ckeditor/ckeditor5-special-characters` package provides special characters grouped into the following categories:
 
@@ -99,6 +99,22 @@ The `@ckeditor/ckeditor5-special-characters` package provides special characters
 - {@link module:special-characters/specialcharactersmathematical~SpecialCharactersMathematical} – Mathematical special characters,
 - {@link module:special-characters/specialcharacterstext~SpecialCharactersText} – text special characters,
 - {@link module:special-characters/specialcharactersessentials~SpecialCharactersEssentials} – combining plugins listed above.
+
+For example, you can limit categories to "Mathematical" and "Currency" only by picking following plugins:
+
+```js
+import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
+import SpecialCharactersCurrency from '@ckeditor/ckeditor5-special-characters/src/SpecialCharactersCurrency';
+import SpecialCharactersMathematical from '@ckeditor/ckeditor5-special-characters/src/SpecialCharactersMathematical';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ SpecialCharacters, SpecialCharactersCurrency, SpecialCharactersMathematical, ... ],
+		toolbar: [ 'specialCharacters', ... ],
+	} )
+	.then( ... )
+	.catch( ... );
+```
 
 ## Installation
 

--- a/src/specialcharacters.js
+++ b/src/specialcharacters.js
@@ -132,6 +132,9 @@ export default class SpecialCharacters extends Plugin {
 	/**
 	 * Adds a collection of special characters to specified group. A title of a special character must be unique.
 	 *
+	 * **Note:** The "All" category name is reserved by the plugin and cannot be used as a new name for special
+	 * characters category.
+	 *
 	 * @param {String} groupName
 	 * @param {Array.<module:special-characters/specialcharacters~SpecialCharacterDefinition>} items
 	 */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Corrected the docs for special characters. Closes ckeditor/ckeditor5#5985.

---

### Additional information

There were a few more changes that I did:

* Moved the information about the "All" category being a reserved category to API docs (this way this information is not only for people reading feature guide, but also for those that discover feature by API docs).
* Added an example for showing just some of all categories.
	* To do that I had to rewrite the way plugins are included. Because option to [remove plugins](https://github.com/ckeditor/ckeditor5/issues/6160) doesn't work for all cases.
* Removed alignment plugin as surely it is not needed here.
* Fixed some typos here and there.
* Code listings use simple function-based plugin form, rather the class extending from `Plugin`. That way people who will have the special chars plugin installed with online builder could benefit from this too.

What I still don't like:

* We have way too much stuff in the toolbar. Our imperative should be to make the feature discovery as easy as possible. Now I bet it's difficult for people that are not working with the editor every day.
* I think that "A title of a special character must be unique across the entire special characters set." should also be moved to `addItems()` but I actually wasn't sure about this one.