### PR TITLE
i/6586: Remove unnecessary styling

### DIFF
--- a/theme/specialcharacters.css
+++ b/theme/specialcharacters.css
@@ -2,11 +2,3 @@
  * Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
-
-.ck.ck-special-characters-navigation {
-	display: flex;
-	flex-direction: row;
-	flex-wrap: nowrap;
-	align-items: center;
-	justify-content: space-between;
-}

--- a/theme/specialcharacters.css
+++ b/theme/specialcharacters.css
@@ -2,3 +2,9 @@
  * Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
+
+/*
+ * Note: This file should contain the wireframe styles only. But since there are no such styles,
+ * it acts as a message to the builder telling that it should look for the corresponding styles
+ * **in the theme** when compiling the editor.
+ */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Removed duplicated styling inherited from `FormHeader` component. See ckeditor/ckeditor5#6586.